### PR TITLE
Add tests about pre releases

### DIFF
--- a/version.go
+++ b/version.go
@@ -93,7 +93,7 @@ func (v *Version) Compare(other *Version) int {
 			return -1
 		}
 
-		panic("proper prerelase compare not done yet")
+		return comparePrereleases(preSelf, preOther)
 	}
 
 	// Compare the segments
@@ -111,6 +111,75 @@ func (v *Version) Compare(other *Version) int {
 	}
 
 	panic("should not be reached")
+}
+
+func comparePrereleases(v string, other string) int {
+	// the same pre release!
+	if v == other {
+		return 0
+	}
+
+	// split both pre releases for analyse their parts
+	selfPreReleaseMeta := strings.Split(v, ".")
+	otherPreReleaseMeta := strings.Split(other, ".")
+
+	selfPreReleaseLen := len(selfPreReleaseMeta)
+	otherPreReleaseLen := len(otherPreReleaseMeta)
+
+	biggestLen := otherPreReleaseLen
+	if selfPreReleaseLen > otherPreReleaseLen {
+		biggestLen = selfPreReleaseLen
+	}
+
+	// loop for parts to find the first difference
+	for i:=0; i < biggestLen; i = i +1 {
+		partSelfPre := ""
+		if i < selfPreReleaseLen {
+			partSelfPre = selfPreReleaseMeta[i]
+		}
+
+		partOtherPre := ""
+		if i < otherPreReleaseLen {
+			partOtherPre = otherPreReleaseMeta[i]
+		}		
+
+		compare := comparePart(partSelfPre, partOtherPre)
+		// if parts are equals, continue the loop
+		if compare != 0 {
+			return compare
+		}
+	}
+
+	return 0
+}
+
+func comparePart(preSelf string, preOther string) int {
+	if preSelf == preOther {
+		return 0
+	}
+
+	// if a part is empty, we use the other to decide
+	if preSelf == "" {
+		_, notIsNumeric := strconv.ParseInt(preOther, 10, 64) 
+		if notIsNumeric == nil {
+			return -1
+		}
+		return 1
+	}
+
+	if preOther == "" {
+		_, notIsNumeric := strconv.ParseInt(preSelf, 10, 64) 
+		if notIsNumeric == nil {
+			return 1
+		}
+		return -1
+	}
+
+	if preSelf > preOther {
+		return 1
+	}
+
+	return -1
 }
 
 // Equal tests if two versions are equal.

--- a/version_test.go
+++ b/version_test.go
@@ -67,6 +67,47 @@ func TestVersionCompare(t *testing.T) {
 	}
 }
 
+func TestComparePreReleases(t *testing.T) {
+	cases := []struct {
+		v1       string
+		v2       string
+		expected int
+	}{
+		{"1.2-beta.2", "1.2-beta.2", 0},
+		{"1.2-beta.1", "1.2-beta.2", -1},
+		{"3.2-alpha.1", "3.2-alpha", 1},
+		{"1.2-beta.2", "1.2-beta.1", 1},
+		{"1.2-beta", "1.2-beta.3", -1},
+		{"1.2-alpha", "1.2-beta.3", -1},
+		{"1.2-beta", "1.2-alpha.3", 1},
+		{"3.0-alpha.3", "3.0-rc.1", -1},
+		{"3.0-alpha3", "3.0-rc1", -1},
+		{"3.0-alpha.1", "3.0-alpha.beta", -1},
+		{"5.4-alpha", "5.4-alpha.beta", 1},
+	}
+
+	for _, tc := range cases {
+		v1, err := NewVersion(tc.v1)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		v2, err := NewVersion(tc.v2)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := v1.Compare(v2)
+		expected := tc.expected
+		if actual != expected {
+			t.Fatalf(
+				"%s <=> %s\nexpected: %d\nactual: %d",
+				tc.v1, tc.v2,
+				expected, actual)
+		}
+	}
+}
+
 func TestVersionMetadata(t *testing.T) {
 	cases := []struct {
 		version  string


### PR DESCRIPTION
I tried add tests and source code about prerelease following the semver precedence:
`1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1`

But probably this patch needs revision. 

:cloud: 
