### PR TITLE
Allow hype in pre-release and metadata

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,8 +15,8 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `([0-9]+(\.[0-9]+){0,2})` +
-	`(-([0-9A-Za-z]+(\.[0-9A-Za-z]+)*))?` +
-	`(\+([0-9A-Za-z]+(\.[0-9A-Za-z]+)*))?` +
+	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`?`
 
 // Version represents a single version.

--- a/version_test.go
+++ b/version_test.go
@@ -19,6 +19,8 @@ func TestNewVersion(t *testing.T) {
 		{"1.2-beta.5", false},
 		{"\n1.2", true},
 		{"1.2.0-x.Y.0+metadata", false},
+		{"1.2.0-x.Y.0+metadata-width-hypen", false},
+		{"1.2.3-rc1-with-hypen", false},
 		{"1.2.3.4", true},
 	}
 


### PR DESCRIPTION
Both relevant points in http://semver.org  9. and 10. definitions are:
  Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-]