### PR TITLE
Adding support for an optional v prefix.

### DIFF
--- a/version.go
+++ b/version.go
@@ -14,7 +14,7 @@ var versionRegexp *regexp.Regexp
 
 // The raw regular expression string used for testing the validity
 // of a version.
-const VersionRegexpRaw string = `([0-9]+(\.[0-9]+){0,2})` +
+const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+){0,2})` +
 	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`?`

--- a/version_test.go
+++ b/version_test.go
@@ -22,6 +22,8 @@ func TestNewVersion(t *testing.T) {
 		{"1.2.0-x.Y.0+metadata-width-hypen", false},
 		{"1.2.3-rc1-with-hypen", false},
 		{"1.2.3.4", true},
+		{"v1.2.3", false},
+		{"foo1.2.3", true},
 	}
 
 	for _, tc := range cases {
@@ -45,6 +47,8 @@ func TestVersionCompare(t *testing.T) {
 		{"1.2", "1.1.4", 1},
 		{"1.2", "1.2-beta", 1},
 		{"1.2+foo", "1.2+beta", 0},
+		{"v1.2", "v1.2-beta", 1},
+		{"v1.2+foo", "v1.2+beta", 0},
 	}
 
 	for _, tc := range cases {
@@ -86,6 +90,9 @@ func TestComparePreReleases(t *testing.T) {
 		{"3.0-alpha3", "3.0-rc1", -1},
 		{"3.0-alpha.1", "3.0-alpha.beta", -1},
 		{"5.4-alpha", "5.4-alpha.beta", 1},
+		{"v1.2-beta.2", "v1.2-beta.2", 0},
+		{"v1.2-beta.1", "v1.2-beta.2", -1},
+		{"v3.2-alpha.1", "v3.2-alpha", 1},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
While not part of the SemVer 2.0.0 spec, the leading v is common. The release tags on SemVer itself have the v prefix. While not part of the spec they are optional in practice.

In practice the SemVer libraries in other languages support the optional v prefix. For example, node-semver (used by npm and common for node.js projects doing versioning) allows [the v prefix](https://github.com/npm/node-semver/blob/5f89ecbe78145ad0b501cf6279f602a23c89738d/semver.js#L111).

Note, my hope is to use this to add support for SemVer to [Glide](https://github.com/Masterminds/glide/)