### PR TITLE
version.NewVersion -> version.New

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -101,7 +101,7 @@ func parseSingle(v string) (*Constraint, error) {
 		return nil, fmt.Errorf("Malformed constraint: %s", v)
 	}
 
-	check, err := NewVersion(matches[2])
+	check, err := New(matches[2])
 	if err != nil {
 		// This is a panic because the regular expression above should
 		// properly validate any version.

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -57,7 +57,7 @@ func TestConstraintCheck(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		v, err := NewVersion(tc.version)
+		v, err := New(tc.version)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/version.go
+++ b/version.go
@@ -31,9 +31,9 @@ func init() {
 	versionRegexp = regexp.MustCompile("^" + VersionRegexpRaw + "$")
 }
 
-// NewVersion parses the given version and returns a new
+// New parses the given version and returns a new
 // Version.
-func NewVersion(v string) (*Version, error) {
+func New(v string) (*Version, error) {
 	matches := versionRegexp.FindStringSubmatch(v)
 	if matches == nil {
 		return nil, fmt.Errorf("Malformed version: %s", v)

--- a/version_collection_test.go
+++ b/version_collection_test.go
@@ -17,7 +17,7 @@ func TestCollection(t *testing.T) {
 
 	versions := make([]*Version, len(versionsRaw))
 	for i, raw := range versionsRaw {
-		v, err := NewVersion(raw)
+		v, err := New(raw)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}

--- a/version_test.go
+++ b/version_test.go
@@ -25,7 +25,7 @@ func TestNewVersion(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		_, err := NewVersion(tc.version)
+		_, err := New(tc.version)
 		if tc.err && err == nil {
 			t.Fatalf("expected error for version: %s", tc.version)
 		} else if !tc.err && err != nil {
@@ -48,12 +48,12 @@ func TestVersionCompare(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v1, err := NewVersion(tc.v1)
+		v1, err := New(tc.v1)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := New(tc.v2)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -89,12 +89,12 @@ func TestComparePreReleases(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v1, err := NewVersion(tc.v1)
+		v1, err := New(tc.v1)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
 
-		v2, err := NewVersion(tc.v2)
+		v2, err := New(tc.v2)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -122,7 +122,7 @@ func TestVersionMetadata(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v, err := NewVersion(tc.version)
+		v, err := New(tc.version)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -147,7 +147,7 @@ func TestVersionPrerelease(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v, err := NewVersion(tc.version)
+		v, err := New(tc.version)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -172,7 +172,7 @@ func TestVersionSegments(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v, err := NewVersion(tc.version)
+		v, err := New(tc.version)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -194,7 +194,7 @@ func TestVersionString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		v, err := NewVersion(tc[0])
+		v, err := New(tc[0])
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}


### PR DESCRIPTION
Hey guys,

While peeking at this library I saw this opportunity for a suggestion.

As https://golang.org/doc/effective_go.html mentions:

> Similarly, the function to make new instances of ring.Ring—which is the definition of a constructor in Go—would normally be called NewRing, but since Ring is the only type exported by the package, and since the package is called ring, it's called just New, which clients of the package see as ring.New. Use the package structure to help you choose good names.

Let me know what you think.

P.S. on the meta side of things, this will require a major version bump :)