### PR TITLE
Fix panic discovered while fuzzing

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -103,9 +103,7 @@ func parseSingle(v string) (*Constraint, error) {
 
 	check, err := NewVersion(matches[2])
 	if err != nil {
-		// This is a panic because the regular expression above should
-		// properly validate any version.
-		panic(err)
+		return nil, err
 	}
 
 	return &Constraint{

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -98,3 +98,14 @@ func TestConstraintsString(t *testing.T) {
 		}
 	}
 }
+
+func TestFuzzCrashers(t *testing.T) {
+
+	var crashers = []string{
+		"11387778780781445675529500000000000000000",
+	}
+
+	for _, s := range crashers {
+		NewConstraint(s)
+	}
+}


### PR DESCRIPTION
OK, now for a real PR!

While fuzzing the library I discovered that this specific panic might happen when an input containing a big version number was given.

```
panic: Error parsing version: strconv.ParseInt: parsing "11387778780781445675529500000000000000000": value out of range

goroutine 1 [running]:
github.com/hashicorp/go-version.parseSingle(0xc820014870, 0x29, 0x1, 0x0, 0x0)
	/var/folders/27/yjth92qs63g482k53zhr_hb80000gn/T/go-fuzz-build816843738/src/github.com/hashicorp/go-version/constraint.go:108 +0x33c
```