### PR TITLE
Relax the version regexp.

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(-?([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
 	`?`
 

--- a/version_test.go
+++ b/version_test.go
@@ -28,6 +28,8 @@ func TestNewVersion(t *testing.T) {
 		{"1.2.3.4", false},
 		{"v1.2.3", false},
 		{"foo1.2.3", true},
+		{"1.7rc2", false},
+		{"v1.7rc2", false},
 	}
 
 	for _, tc := range cases {
@@ -60,6 +62,8 @@ func TestVersionCompare(t *testing.T) {
 		{"v1.2", "v1.2.0.0.1", -1},
 		{"v1.2.0.0", "v1.2.0.0.1", -1},
 		{"v1.2.3.0", "v1.2.3.4", -1},
+		{"1.7rc2", "1.7rc1", 1},
+		{"1.7rc2", "1.7", -1},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Adds support for the go version naming style (i.e. 1.7rc2).