### PR TITLE
fix unintuitive numeric-nonnumeric comparisons of prerelease information

### DIFF
--- a/version.go
+++ b/version.go
@@ -166,24 +166,38 @@ func comparePart(preSelf string, preOther string) int {
 		return 0
 	}
 
+	selfNumeric := true
+	_, err := strconv.ParseInt(preSelf, 10, 64)
+	if err != nil {
+		selfNumeric = false
+	}
+
+	otherNumeric := true
+	_, err = strconv.ParseInt(preOther, 10, 64)
+	if err != nil {
+		otherNumeric = false
+	}
+
 	// if a part is empty, we use the other to decide
 	if preSelf == "" {
-		_, notIsNumeric := strconv.ParseInt(preOther, 10, 64)
-		if notIsNumeric == nil {
+		if otherNumeric {
 			return -1
 		}
 		return 1
 	}
 
 	if preOther == "" {
-		_, notIsNumeric := strconv.ParseInt(preSelf, 10, 64)
-		if notIsNumeric == nil {
+		if selfNumeric {
 			return 1
 		}
 		return -1
 	}
 
-	if preSelf > preOther {
+	if selfNumeric && !otherNumeric {
+		return -1
+	} else if !selfNumeric && otherNumeric {
+		return 1
+	} else if preSelf > preOther {
 		return 1
 	}
 

--- a/version_test.go
+++ b/version_test.go
@@ -108,6 +108,7 @@ func TestComparePreReleases(t *testing.T) {
 		{"v1.2-beta.2", "v1.2-beta.2", 0},
 		{"v1.2-beta.1", "v1.2-beta.2", -1},
 		{"v3.2-alpha.1", "v3.2-alpha", 1},
+		{"v3.2-rc.1-1-g123", "v3.2-rc.2", 1},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Comparing the versions i.e. `1.2.3-rc.2` and `1.2.3-rc.1-1-1hash` I intuitively expected the former to be greater than the latter. Unfortunately, a careful reading of the spec proves that not the case.

Inside http://semver.org/#spec-item-11: `Numeric identifiers always have lower precedence than non-numeric identifiers.`

This PR adds a test for this case, and fixes the behavior of `comparePart()`.

See https://github.com/npm/node-semver/issues/182