### PR TITLE
Fixes version parsing for versions including ~

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,8 +15,8 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-?([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
-	`(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?` +
+	`(-?([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 
 // Version represents a single version.

--- a/version_test.go
+++ b/version_test.go
@@ -24,6 +24,7 @@ func TestNewVersion(t *testing.T) {
 		{"1.2.3.4", false},
 		{"1.2.0.4-x.Y.0+metadata", false},
 		{"1.2.0.4-x.Y.0+metadata-width-hypen", false},
+		{"1.2.0-X-1.2.0+metadata~dist", false},
 		{"1.2.3.4-rc1-with-hypen", false},
 		{"1.2.3.4", false},
 		{"v1.2.3", false},
@@ -64,6 +65,7 @@ func TestVersionCompare(t *testing.T) {
 		{"v1.2.3.0", "v1.2.3.4", -1},
 		{"1.7rc2", "1.7rc1", 1},
 		{"1.7rc2", "1.7", -1},
+		{"1.2.0", "1.2.0-X-1.2.0+metadata~dist", 1},
 	}
 
 	for _, tc := range cases {
@@ -142,6 +144,7 @@ func TestVersionMetadata(t *testing.T) {
 		{"1.2-beta", ""},
 		{"1.2.0-x.Y.0", ""},
 		{"1.2.0-x.Y.0+metadata", "metadata"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata~dist"},
 	}
 
 	for _, tc := range cases {
@@ -167,6 +170,7 @@ func TestVersionPrerelease(t *testing.T) {
 		{"1.2-beta", "beta"},
 		{"1.2.0-x.Y.0", "x.Y.0"},
 		{"1.2.0-x.Y.0+metadata", "x.Y.0"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata-1.2.0"},
 	}
 
 	for _, tc := range cases {
@@ -192,6 +196,7 @@ func TestVersionSegments(t *testing.T) {
 		{"1.2-beta", []int{1, 2, 0}},
 		{"1-x.Y.0", []int{1, 0, 0}},
 		{"1.2.0-x.Y.0+metadata", []int{1, 2, 0}},
+		{"1.2.0-metadata-1.2.0+metadata~dist", []int{1, 2, 0}},
 	}
 
 	for _, tc := range cases {
@@ -240,6 +245,7 @@ func TestVersionString(t *testing.T) {
 		{"1.2-beta", "1.2.0-beta"},
 		{"1.2.0-x.Y.0", "1.2.0-x.Y.0"},
 		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
+		{"1.2.0-metadata-1.2.0+metadata~dist", "1.2.0-metadata-1.2.0+metadata~dist"},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
- Closes https://github.com/terraform-providers/terraform-provider-mysql/issues/6
- `~` comes in a lot of packages as part of the Debian package versioning: http://aalvarez.me/blog/posts/debian-package-versioning.html