### PR TITLE
When using a specific pattern, unintended results are returned.

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-?([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 
@@ -59,9 +59,14 @@ func NewVersion(v string) (*Version, error) {
 		segments = append(segments, 0)
 	}
 
+	pre := matches[7]
+	if pre == ""{
+		pre = matches[4]
+	}
+
 	return &Version{
-		metadata: matches[7],
-		pre:      matches[4],
+		metadata: matches[10],
+		pre:      pre,
 		segments: segments,
 		si:       si,
 	}, nil

--- a/version_test.go
+++ b/version_test.go
@@ -14,6 +14,7 @@ func TestNewVersion(t *testing.T) {
 		{"1.0", false},
 		{"1", false},
 		{"1.2.beta", true},
+		{"1.21.beta", true},
 		{"foo", true},
 		{"1.2-5", false},
 		{"1.2-beta.5", false},
@@ -171,6 +172,7 @@ func TestVersionPrerelease(t *testing.T) {
 		{"1.2.3", ""},
 		{"1.2-beta", "beta"},
 		{"1.2.0-x.Y.0", "x.Y.0"},
+		{"1.2.0-7.Y.0", "7.Y.0"},
 		{"1.2.0-x.Y.0+metadata", "x.Y.0"},
 		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata-1.2.0"},
 	}


### PR DESCRIPTION
ref #37 

Fixed a problem of correcting unexpected results for a specific pattern by modifying the regular expression.