### PR TITLE
Support Original to return original version

### DIFF
--- a/version.go
+++ b/version.go
@@ -25,6 +25,7 @@ type Version struct {
 	pre      string
 	segments []int64
 	si       int
+	original string
 }
 
 func init() {
@@ -69,6 +70,7 @@ func NewVersion(v string) (*Version, error) {
 		pre:      pre,
 		segments: segments,
 		si:       si,
+		original: v,
 	}, nil
 }
 
@@ -311,6 +313,12 @@ func (v *Version) Segments64() []int64 {
 
 // String returns the full version string included pre-release
 // and metadata information.
+//
+// This value is rebuilt according to the parsed segments and other
+// information. Therefore, ambiguities in the version string such as
+// prefixed zeroes (1.04.0 => 1.4.0), `v` prefix (v1.0.0 => 1.0.0), and
+// missing parts (1.0 => 1.0.0) will be made into a canonicalized form
+// as shown in the parenthesized examples.
 func (v *Version) String() string {
 	var buf bytes.Buffer
 	fmtParts := make([]string, len(v.segments))
@@ -328,4 +336,10 @@ func (v *Version) String() string {
 	}
 
 	return buf.String()
+}
+
+// Original returns the original parsed version as-is, including any
+// potential whitespace, `v` prefix, etc.
+func (v *Version) Original() string {
+	return v.original
 }

--- a/version_test.go
+++ b/version_test.go
@@ -175,6 +175,7 @@ func TestVersionPrerelease(t *testing.T) {
 		{"1.2.0-7.Y.0", "7.Y.0"},
 		{"1.2.0-x.Y.0+metadata", "x.Y.0"},
 		{"1.2.0-metadata-1.2.0+metadata~dist", "metadata-1.2.0"},
+		{"17.03.0-ce", "ce"}, // zero-padded fields
 	}
 
 	for _, tc := range cases {
@@ -201,6 +202,7 @@ func TestVersionSegments(t *testing.T) {
 		{"1-x.Y.0", []int{1, 0, 0}},
 		{"1.2.0-x.Y.0+metadata", []int{1, 2, 0}},
 		{"1.2.0-metadata-1.2.0+metadata~dist", []int{1, 2, 0}},
+		{"17.03.0-ce", []int{17, 3, 0}}, // zero-padded fields
 	}
 
 	for _, tc := range cases {
@@ -250,6 +252,7 @@ func TestVersionString(t *testing.T) {
 		{"1.2.0-x.Y.0", "1.2.0-x.Y.0"},
 		{"1.2.0-x.Y.0+metadata", "1.2.0-x.Y.0+metadata"},
 		{"1.2.0-metadata-1.2.0+metadata~dist", "1.2.0-metadata-1.2.0+metadata~dist"},
+		{"17.03.0-ce", "17.3.0-ce"}, // zero-padded fields
 	}
 
 	for _, tc := range cases {
@@ -262,6 +265,9 @@ func TestVersionString(t *testing.T) {
 		expected := tc[1]
 		if actual != expected {
 			t.Fatalf("expected: %s\nactual: %s", expected, actual)
+		}
+		if actual := v.Original(); actual != tc[0] {
+			t.Fatalf("expected original: %q\nactual: %q", tc[0], actual)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #16, #27

This keeps track of the original version that was parsed and makes it
available as `v.Original`. Additionally, I updated the String docs to
note that the returned value is canonicalized according to some set of
rules.