### PR TITLE
Segments64 makes a copy to match Segments

### DIFF
--- a/version.go
+++ b/version.go
@@ -306,7 +306,9 @@ func (v *Version) Segments() []int {
 // for a version "1.2.3-beta", segments will return a slice of
 // 1, 2, 3.
 func (v *Version) Segments64() []int64 {
-	return v.segments
+	result := make([]int64, len(v.segments))
+	copy(result, v.segments)
+	return result
 }
 
 // String returns the full version string included pre-release

--- a/version_test.go
+++ b/version_test.go
@@ -240,6 +240,15 @@ func TestVersionSegments64(t *testing.T) {
 		if !reflect.DeepEqual(actual, expected) {
 			t.Fatalf("expected: %#v\nactual: %#v", expected, actual)
 		}
+
+		{
+			expected := actual[0]
+			actual[0]++
+			actual = v.Segments64()
+			if actual[0] != expected {
+				t.Fatalf("Segments64 is mutable")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #24

Segments and Segments64 should behave identically and its surprising
they don't. I don't think any downstreams depend on the performance
guarantees of returning the exact slice (no copy), especially since the
segments are so small to begin with, but if that's the case we can
always introduce a new func to return the reference.