### PR TITLE
Adhere to semvar pre-release separator

### DIFF
--- a/version.go
+++ b/version.go
@@ -15,7 +15,7 @@ var versionRegexp *regexp.Regexp
 // The raw regular expression string used for testing the validity
 // of a version.
 const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 	`?`
 

--- a/version_test.go
+++ b/version_test.go
@@ -10,6 +10,7 @@ func TestNewVersion(t *testing.T) {
 		version string
 		err     bool
 	}{
+		{"", true},
 		{"1.2.3", false},
 		{"1.0", false},
 		{"1", false},
@@ -30,16 +31,16 @@ func TestNewVersion(t *testing.T) {
 		{"1.2.3.4", false},
 		{"v1.2.3", false},
 		{"foo1.2.3", true},
-		{"1.7rc2", false},
-		{"v1.7rc2", false},
+		{"1.7rc2", true},
+		{"v1.7rc2", true},
 	}
 
 	for _, tc := range cases {
 		_, err := NewVersion(tc.version)
 		if tc.err && err == nil {
-			t.Fatalf("expected error for version: %s", tc.version)
+			t.Fatalf("expected error for version: %q", tc.version)
 		} else if !tc.err && err != nil {
-			t.Fatalf("error for version %s: %s", tc.version, err)
+			t.Fatalf("error for version %q: %s", tc.version, err)
 		}
 	}
 }
@@ -64,8 +65,6 @@ func TestVersionCompare(t *testing.T) {
 		{"v1.2", "v1.2.0.0.1", -1},
 		{"v1.2.0.0", "v1.2.0.0.1", -1},
 		{"v1.2.3.0", "v1.2.3.4", -1},
-		{"1.7rc2", "1.7rc1", 1},
-		{"1.7rc2", "1.7", -1},
 		{"1.2.0", "1.2.0-X-1.2.0+metadata~dist", 1},
 	}
 


### PR DESCRIPTION
The semvar specifications [X.Y.Z](https://semver.org/#spec-item-2) states Z must be non-negative integers. Without a hyphen `-` between the version and a pre-release identifier, Z is no longer an integer and is alphanumeric.

> A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes. X is the major version, Y is the minor version, and Z is the patch version. Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0

_this is introducing a backwards incompatible change_