### PR TITLE
Add new constructor that strictly adheres to semver specs

### DIFF
--- a/version.go
+++ b/version.go
@@ -10,14 +10,25 @@ import (
 )
 
 // The compiled regular expression used to test the validity of a version.
-var versionRegexp *regexp.Regexp
+var (
+	versionRegexp *regexp.Regexp
+	semverRegexp  *regexp.Regexp
+)
 
 // The raw regular expression string used for testing the validity
 // of a version.
-const VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
-	`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
-	`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
-	`?`
+const (
+	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+
+	// SemverRegexpRaw requires a separator between version and prerelease
+	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+)
 
 // Version represents a single version.
 type Version struct {
@@ -30,12 +41,24 @@ type Version struct {
 
 func init() {
 	versionRegexp = regexp.MustCompile("^" + VersionRegexpRaw + "$")
+	semverRegexp = regexp.MustCompile("^" + SemverRegexpRaw + "$")
 }
 
 // NewVersion parses the given version and returns a new
 // Version.
 func NewVersion(v string) (*Version, error) {
-	matches := versionRegexp.FindStringSubmatch(v)
+	return newVersion(v, versionRegexp)
+}
+
+// NewSemver parses the given version and returns a new
+// Version that adheres strictly to SemVer specs
+// https://semver.org/
+func NewSemver(v string) (*Version, error) {
+	return newVersion(v, semverRegexp)
+}
+
+func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
+	matches := pattern.FindStringSubmatch(v)
 	if matches == nil {
 		return nil, fmt.Errorf("Malformed version: %s", v)
 	}


### PR DESCRIPTION
The changes below adds a new optional constructor that strictly adheres to [semver pre-release specs](https://semver.org/#spec-item-9)
1. Requires versions with pre-releases to have the `-` separator
2. Non-empty pre-release identifier

Without the hyphen `-` separator between the version and pre-release, it adds complexity to parse for X.Y.Z as non-negative integers -- where the Z component encompasses the pre-release and becomes alphanumeric