### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -77,7 +77,7 @@ func (cs Constraints) Check(v *Version) bool {
 	return true
 }
 
-// Returns the string format of the constraints
+// String returns the string format of the constraints
 func (cs Constraints) String() string {
 	csStr := make([]string, len(cs))
 	for i, c := range cs {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._