### PR TITLE
Bug: rc1 is greater than rc11

### DIFF
--- a/version_test.go
+++ b/version_test.go
@@ -195,6 +195,8 @@ func TestComparePreReleases(t *testing.T) {
 		{"v1.2-beta.1", "v1.2-beta.2", -1},
 		{"v3.2-alpha.1", "v3.2-alpha", 1},
 		{"v3.2-rc.1-1-g123", "v3.2-rc.2", 1},
+		{"1.0.0-rc9", "1.0.0-rc10", -1},
+		{"v1.0.0-rc9", "1.0.0-rc10", -1},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
I believe that 1.0.0-rc1 is a fairly standard semver format and one would expect that rc11 is greater than rc1