### PR TITLE
update circle config to save go mod cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,14 @@ jobs:
       - restore_cache: # restore cache from dev-build job
           keys:
             - go-version-modcache-v1-{{ checksum "go.mod" }}
-            - go-version-modcache-v1
+
+      - run: go mod download
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: go-version-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -45,12 +52,6 @@ jobs:
           path: *TEST_RESULTS_PATH
       - store_artifacts:
           path: *TEST_RESULTS_PATH
-
-      # Save go module cache if the go.mod file has changed
-      - save_cache:
-          key: go-version-modcache-v1-{{ checksum "go.mod" }}
-          paths:
-            - "/go/pkg/mod"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,12 +24,7 @@ jobs:
       - restore_cache: # restore cache from dev-build job
           keys:
             - go-version-modcache-v1-{{ checksum "go.mod" }}
-
-      # Save go module cache if the go.mod file has changed
-      - save_cache:
-          key: go-version-modcache-v1-{{ checksum "go.mod" }}
-          paths:
-            - "/go/pkg/mod"
+            - go-version-modcache-v1
 
       # check go fmt output because it does not report non-zero when there are fmt changes
       - run:
@@ -50,6 +45,12 @@ jobs:
           path: *TEST_RESULTS_PATH
       - store_artifacts:
           path: *TEST_RESULTS_PATH
+
+      # Save go module cache if the go.mod file has changed
+      - save_cache:
+          key: go-version-modcache-v1-{{ checksum "go.mod" }}
+          paths:
+            - "/go/pkg/mod"
 
 workflows:
   version: 2


### PR DESCRIPTION
Updating circleci config to save go mod cache in response to: https://github.com/hashicorp/go-version/pull/64#discussion_r333114060