### PR TITLE
Add nil check to Version.Equal

### DIFF
--- a/version.go
+++ b/version.go
@@ -280,6 +280,10 @@ func comparePrereleases(v string, other string) int {
 
 // Equal tests if two versions are equal.
 func (v *Version) Equal(o *Version) bool {
+	if v == nil || o == nil {
+		return v == o
+	}
+
 	return v.Compare(o) == 0
 }
 

--- a/version_test.go
+++ b/version_test.go
@@ -172,6 +172,32 @@ func TestVersionCompare_versionAndSemver(t *testing.T) {
 	}
 }
 
+func TestVersionEqual_nil(t *testing.T) {
+	mustVersion := func(v string) *Version {
+		ver, err := NewVersion(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ver
+	}
+	cases := []struct {
+		leftVersion  *Version
+		rightVersion *Version
+		expected     bool
+	}{
+		{mustVersion("1.0.0"), nil, false},
+		{nil, mustVersion("1.0.0"), false},
+		{nil, nil, true},
+	}
+
+	for _, tc := range cases {
+		given := tc.leftVersion.Equal(tc.rightVersion)
+		if given != tc.expected {
+			t.Fatalf("expected Equal to nil to be %t", tc.expected)
+		}
+	}
+}
+
 func TestComparePreReleases(t *testing.T) {
 	cases := []struct {
 		v1       string


### PR DESCRIPTION
I avoided adding similar check to `Compare` as the meaning of any integer value there could be misleading, but I believe that the check in `Equal` is useful e.g. in test cases where `nil` can appear and equality is checked, either directly, or via library such as https://github.com/google/go-cmp which calls `Equal` on any struct via reflection.

Such comparisons panic without this patch and therefore don't provide useful output from tests.