### PR TITLE
Add support for prefix of any character

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/go-version
+
+go 1.15

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,1 @@
 module github.com/hashicorp/go-version
-
-go 1.15

--- a/version.go
+++ b/version.go
@@ -18,13 +18,13 @@ var (
 // The raw regular expression string used for testing the validity
 // of a version.
 const (
-	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+	VersionRegexpRaw string = `(?:\w+\-)?v?([0-9]+(\.[0-9]+)*?)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`
 
 	// SemverRegexpRaw requires a separator between version and prerelease
-	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+	SemverRegexpRaw string = `(?:\w+\-)?v?([0-9]+(\.[0-9]+)*?)` +
 		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
 		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
 		`?`

--- a/version_test.go
+++ b/version_test.go
@@ -34,6 +34,7 @@ func TestNewVersion(t *testing.T) {
 		{"1.7rc2", false},
 		{"v1.7rc2", false},
 		{"1.0-", false},
+		{"controller-v0.40.2", false},
 	}
 
 	for _, tc := range cases {
@@ -75,6 +76,7 @@ func TestNewSemver(t *testing.T) {
 		{"1.7rc2", true},
 		{"v1.7rc2", true},
 		{"1.0-", true},
+		{"controller-v0.40.2", false},
 	}
 
 	for _, tc := range cases {
@@ -110,6 +112,9 @@ func TestVersionCompare(t *testing.T) {
 		{"1.7rc2", "1.7rc1", 1},
 		{"1.7rc2", "1.7", -1},
 		{"1.2.0", "1.2.0-X-1.2.0+metadata~dist", 1},
+		{"controller-v0.40.2", "controller-v0.40.3", -1},
+		{"0.40.4", "controller-v0.40.2", 1},
+		{"0.40.4", "controller-v0.40.4", 0},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
To support releases with other prefixes than "v", such as the `ingress-nginx`
https://github.com/kubernetes/ingress-nginx/releases