### PR TITLE
Switch to docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:latest
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.15.3
   environments:
     tmp: &TEST_RESULTS_PATH /tmp/test-results # path to where test results are saved
 


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 