### PR TITLE
Introduce `MustConstraints()`

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -66,6 +66,16 @@ func NewConstraint(v string) (Constraints, error) {
 	return Constraints(result), nil
 }
 
+// MustConstraints is a helper that wraps a call to a function
+// returning (Constraints, error) and panics if error is non-nil.
+func MustConstraints(c Constraints, err error) Constraints {
+	if err != nil {
+		panic(err)
+	}
+
+	return c
+}
+
 // Check tests if a version satisfies all the constraints.
 func (cs Constraints) Check(v *Version) bool {
 	for _, c := range cs {


### PR DESCRIPTION
This is mainly useful in downstream tests which are testing anything that takes version constraints as input and follows the "convention" of the existing [`Must()`](https://pkg.go.dev/github.com/hashicorp/go-version#Must) for `Version`.