### PR TITLE
Constraint(s): introduce `Equals()` and `sort.Interface`

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -11,8 +12,13 @@ import (
 // ">= 1.0".
 type Constraint struct {
 	f        constraintFunc
+	op       operator
 	check    *Version
 	original string
+}
+
+func (c *Constraint) Equals(con *Constraint) bool {
+	return c.op == con.op && c.check.Equal(con.check)
 }
 
 // Constraints is a slice of constraints. We make a custom type so that
@@ -21,20 +27,25 @@ type Constraints []*Constraint
 
 type constraintFunc func(v, c *Version) bool
 
-var constraintOperators map[string]constraintFunc
+var constraintOperators map[string]constraintOperation
+
+type constraintOperation struct {
+	op operator
+	f  constraintFunc
+}
 
 var constraintRegexp *regexp.Regexp
 
 func init() {
-	constraintOperators = map[string]constraintFunc{
-		"":   constraintEqual,
-		"=":  constraintEqual,
-		"!=": constraintNotEqual,
-		">":  constraintGreaterThan,
-		"<":  constraintLessThan,
-		">=": constraintGreaterThanEqual,
-		"<=": constraintLessThanEqual,
-		"~>": constraintPessimistic,
+	constraintOperators = map[string]constraintOperation{
+		"":   {op: equal, f: constraintEqual},
+		"=":  {op: equal, f: constraintEqual},
+		"!=": {op: notEqual, f: constraintNotEqual},
+		">":  {op: greaterThan, f: constraintGreaterThan},
+		"<":  {op: lessThan, f: constraintLessThan},
+		">=": {op: greaterThanEqual, f: constraintGreaterThanEqual},
+		"<=": {op: lessThanEqual, f: constraintLessThanEqual},
+		"~>": {op: pessimistic, f: constraintPessimistic},
 	}
 
 	ops := make([]string, 0, len(constraintOperators))
@@ -77,6 +88,56 @@ func (cs Constraints) Check(v *Version) bool {
 	return true
 }
 
+// Equals compares Constraints with other Constraints
+// for equality. This may not represent logical equivalence
+// of compared constraints.
+// e.g. even though '>0.1,>0.2' is logically equivalent
+// to '>0.2' it is *NOT* treated as equal.
+//
+// Missing operator is treated as equal to '=', whitespaces
+// are ignored and constraints are sorted before comaparison.
+func (cs Constraints) Equals(c Constraints) bool {
+	if len(cs) != len(c) {
+		return false
+	}
+
+	// make copies to retain order of the original slices
+	left := make(Constraints, len(cs))
+	copy(left, cs)
+	sort.Stable(left)
+	right := make(Constraints, len(c))
+	copy(right, c)
+	sort.Stable(right)
+
+	// compare sorted slices
+	for i, con := range left {
+		if !con.Equals(right[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (cs Constraints) Len() int {
+	return len(cs)
+}
+
+func (cs Constraints) Less(i, j int) bool {
+	if cs[i].op < cs[j].op {
+		return true
+	}
+	if cs[i].op > cs[j].op {
+		return false
+	}
+
+	return cs[i].check.LessThan(cs[j].check)
+}
+
+func (cs Constraints) Swap(i, j int) {
+	cs[i], cs[j] = cs[j], cs[i]
+}
+
 // Returns the string format of the constraints
 func (cs Constraints) String() string {
 	csStr := make([]string, len(cs))
@@ -107,8 +168,11 @@ func parseSingle(v string) (*Constraint, error) {
 		return nil, err
 	}
 
+	cop := constraintOperators[matches[1]]
+
 	return &Constraint{
-		f:        constraintOperators[matches[1]],
+		f:        cop.f,
+		op:       cop.op,
 		check:    check,
 		original: v,
 	}, nil
@@ -137,6 +201,18 @@ func prereleaseCheck(v, c *Version) bool {
 //-------------------------------------------------------------------
 // Constraint functions
 //-------------------------------------------------------------------
+
+type operator rune
+
+const (
+	equal            operator = '='
+	notEqual         operator = '≠'
+	greaterThan      operator = '>'
+	lessThan         operator = '<'
+	greaterThanEqual operator = '≥'
+	lessThanEqual    operator = '≤'
+	pessimistic      operator = '~'
+)
 
 func constraintEqual(v, c *Version) bool {
 	return v.Equal(c)

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -1,6 +1,9 @@
 package version
 
 import (
+	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -94,6 +97,104 @@ func TestConstraintCheck(t *testing.T) {
 			t.Fatalf("Version: %s\nConstraint: %s\nExpected: %#v",
 				tc.version, tc.constraint, expected)
 		}
+	}
+}
+
+func TestConstraintEqual(t *testing.T) {
+	cases := []struct {
+		leftConstraint  string
+		rightConstraint string
+		expectedEqual   bool
+	}{
+		{
+			"0.0.1",
+			"0.0.1",
+			true,
+		},
+		{ // whitespaces
+			" 0.0.1 ",
+			"0.0.1",
+			true,
+		},
+		{ // equal op implied
+			"=0.0.1 ",
+			"0.0.1",
+			true,
+		},
+		{ // version difference
+			"=0.0.1",
+			"=0.0.2",
+			false,
+		},
+		{ // operator difference
+			">0.0.1",
+			"=0.0.1",
+			false,
+		},
+		{ // different order
+			">0.1.0, <=1.0.0",
+			"<=1.0.0, >0.1.0",
+			true,
+		},
+	}
+
+	for _, tc := range cases {
+		leftCon, err := NewConstraint(tc.leftConstraint)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+		rightCon, err := NewConstraint(tc.rightConstraint)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := leftCon.Equals(rightCon)
+		if actual != tc.expectedEqual {
+			t.Fatalf("Constraints: %s vs %s\nExpected: %t\nActual: %t",
+				tc.leftConstraint, tc.rightConstraint, tc.expectedEqual, actual)
+		}
+	}
+}
+
+func TestConstraint_sort(t *testing.T) {
+	cases := []struct {
+		constraint          string
+		expectedConstraints string
+	}{
+		{
+			">= 0.1.0,< 1.12",
+			"< 1.12,>= 0.1.0",
+		},
+		{
+			"< 1.12,>= 0.1.0",
+			"< 1.12,>= 0.1.0",
+		},
+		{
+			"< 1.12,>= 0.1.0,0.2.0",
+			"< 1.12,0.2.0,>= 0.1.0",
+		},
+		{
+			">1.0,>0.1.0,>0.3.0,>0.2.0",
+			">0.1.0,>0.2.0,>0.3.0,>1.0",
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			c, err := NewConstraint(tc.constraint)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			sort.Sort(c)
+
+			actual := c.String()
+
+			if !reflect.DeepEqual(actual, tc.expectedConstraints) {
+				t.Fatalf("unexpected order\nexpected: %#v\nactual: %#v",
+					tc.expectedConstraints, actual)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This is to allow us over in [`terraform-ls`](https://github.com/hashicorp/terraform-ls) to detect configuration changes in Terraform core/provider version requirements more accurately and avoid triggering any unnecessary background jobs e.g. reloading schema version just due to whitespaces.

The accuracy is rather a (positive) side effect of the implementation though, the main motivation was to have a single upstream equality function that we can call directly without having to maintain the logic downstream.

I guess it would be nice if `Constraints.String()` returned more "normalized" (sorted and whitespace-trimmed) constraints, but I'm afraid that ship has sailed and there would need to be a strong use case to weigh against the breaking change. This is also why as part of sorting I still intentionally kept the original order intact by copying - to avoid breaking changes.