### PR TITLE
Add Prerelease function onto Constraint struct

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -163,6 +163,12 @@ func (c *Constraint) Check(v *Version) bool {
 	return c.f(v, c.check)
 }
 
+// Prerelease returns true if the version underlying this constraint
+// contains a prerelease field.
+func (c *Constraint) Prerelease() bool {
+	return len(c.check.Prerelease()) > 0
+}
+
 func (c *Constraint) String() string {
 	return c.original
 }

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -100,6 +100,34 @@ func TestConstraintCheck(t *testing.T) {
 	}
 }
 
+func TestConstraintPrerelease(t *testing.T) {
+	cases := []struct {
+		constraint string
+		prerelease bool
+	}{
+		{"= 1.0", false},
+		{"= 1.0-beta", true},
+		{"~> 2.1.0", false},
+		{"~> 2.1.0-dev", true},
+		{"> 2.0", false},
+		{">= 2.1.0-a", true},
+	}
+
+	for _, tc := range cases {
+		c, err := parseSingle(tc.constraint)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		actual := c.Prerelease()
+		expected := tc.prerelease
+		if actual != expected {
+			t.Fatalf("Constraint: %s\nExpected: %#v",
+				tc.constraint, expected)
+		}
+	}
+}
+
 func TestConstraintEqual(t *testing.T) {
 	cases := []struct {
 		leftConstraint  string


### PR DESCRIPTION
New function will return true if the underlying version contains a prerelease field.

This can be used within the github.com/hashicorp/terraform repository to fail versioning checks if the constraints contain a prerelease field. Example: https://github.com/liamcervante/terraform/pull/1

Root issue: https://github.com/hashicorp/terraform/issues/28148 