### PR TITLE
Add benchmark test for version.String()

### DIFF
--- a/version_test.go
+++ b/version_test.go
@@ -731,7 +731,7 @@ func TestLessThanOrEqual(t *testing.T) {
 
 func BenchmarkVersionString(b *testing.B) {
 	v, _ := NewVersion("3.4.5-rc1+meta")
-	_ = v.String() // warm the cache
+	_ = v.String()
 
 	b.ResetTimer()
 	b.ReportAllocs()


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
Benchmark Results:
<img width="1251" alt="image" src="https://github.com/user-attachments/assets/a188908a-86cd-466b-9313-2df2cb57142d" />
Number of memory allocations per operation: 8 individual allocations per call to String()
This causes GC pressure and slowdowns when called in large volume systems.

If this function is called 1 million times, that’s 8 million allocations, which leads to OOM in our case.

## Related Issue
https://github.com/hashicorp/go-version/issues/118

## How Has This Been Tested?
Clone this branch and run
`go test -bench=BenchmarkVersionString`