### PR TITLE
use original field for quick, efficient equality check

### DIFF
--- a/version.go
+++ b/version.go
@@ -116,7 +116,7 @@ func Must(v *Version, err error) *Version {
 // GreaterThan, GreaterThanOrEqual or LessThanOrEqual methods.
 func (v *Version) Compare(other *Version) int {
 	// A quick, efficient equality check
-	if v.String() == other.String() {
+	if v.original == other.original {
 		return 0
 	}
 

--- a/version_test.go
+++ b/version_test.go
@@ -728,3 +728,13 @@ func TestLessThanOrEqual(t *testing.T) {
 		}
 	}
 }
+func BenchmarkVersionCompare(b *testing.B) {
+	v, _ := NewVersion("3.4.5-rc1+meta")
+	v.Compare(v)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		v.Compare(v)
+	}
+}


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description
Fix for high memory count on call to Compare()

## Related Issue
https://github.com/hashicorp/go-version/issues/118

## How Has This Been Tested?
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/664467d0-c8dc-431b-88b2-8396cda383a8" />
