### PR TITLE
Add explicit go version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/hashicorp/go-version
+
+go 1.16


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Description

This PR adds `go 1.16` to `go.mod`. It's better to explicitly state the minimum supported Go version.

The section from https://go.dev/ref/mod#go-mod-file-go states: "If the go directive is missing, go 1.16 is assumed."

## How Has This Been Tested?

Install Go 1.16 and run tests with it:

```console
❯ go1.16 version
go version go1.16 darwin/arm64
❯ go1.16 test -count=1 ./...
ok      github.com/hashicorp/go-version 0.638s
```