### PR TITLE
fix: render zero-value Version as canonical "0.0.0" (#170)

### DIFF
--- a/version.go
+++ b/version.go
@@ -439,7 +439,16 @@ func (v *Version) String() string {
 
 func (v *Version) bytes() []byte {
 	var buf []byte
-	for i, s := range v.segments {
+	segments := v.segments
+	if len(segments) == 0 {
+		// A zero-value Version (e.g. &Version{}) has no parsed segments.
+		// Render it as the canonical semver zero so String() stays
+		// consistent with Compare/Equal, which already treat it as equal
+		// to "0.0.0", and with the MAJOR.MINOR.PATCH minimum that
+		// newVersion pads every parsed version to.
+		segments = []int64{0, 0, 0}
+	}
+	for i, s := range segments {
 		if i > 0 {
 			buf = append(buf, '.')
 		}

--- a/version_test.go
+++ b/version_test.go
@@ -626,6 +626,30 @@ func TestVersionString(t *testing.T) {
 	}
 }
 
+func TestVersionStringZeroValue(t *testing.T) {
+	// A zero-value Version compares equal to "0.0.0" (see Compare/Equal),
+	// so its String() must render the same canonical value instead of an
+	// empty string. Regression test for hashicorp/go-version#170.
+	zero := &Version{}
+	if actual := zero.String(); actual != "0.0.0" {
+		t.Fatalf("expected zero-value String() to be %q, got %q", "0.0.0", actual)
+	}
+
+	semverZero, err := NewSemver("0.0.0")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if !zero.Equal(semverZero) {
+		t.Fatalf("expected zero-value Version to equal %q", semverZero)
+	}
+	if zero.String() != semverZero.String() {
+		t.Fatalf(
+			"equal versions disagree on String(): zero=%q semverZero=%q",
+			zero.String(), semverZero.String(),
+		)
+	}
+}
+
 func TestEqual(t *testing.T) {
 	cases := []struct {
 		v1       string


### PR DESCRIPTION
Closes #170.

## Problem

A zero-value `Version` compares **equal** to `0.0.0`, but its `String()` returns an **empty string** — so two values that `Equal` reports as identical disagree on their textual form:

```go
v := &version.Version{}
vv, _ := version.NewSemver("0.0.0")

v.Equal(vv)   // true
vv.String()   // "0.0.0"
v.String()    // ""  ← inconsistent
```

`String()`/`bytes()` ranges over `segments`, which is `nil` for an unparsed zero value, so nothing is written.

## Fix

`newVersion` already pads every parsed version to a 3-segment `MAJOR.MINOR.PATCH` minimum, and `Compare`/`Equal` already treat the zero value as equal to `0.0.0`. So when `segments` is empty, `bytes()` now renders the canonical `0.0.0` to match.

The new branch is only ever taken for the zero value — every `Version` built through `NewVersion`/`NewSemver` already has ≥3 segments, so existing behaviour is unchanged.

## Tests

Added `TestVersionStringZeroValue`, which asserts `(&Version{}).String() == "0.0.0"` and that an `Equal` zero value and `NewSemver("0.0.0")` agree on `String()`. It fails before this change (`got ""`) and passes after.

```
$ go test ./...
ok  	github.com/hashicorp/go-version
$ gofmt -l version.go version_test.go   # clean
$ go vet ./...                           # clean
```