### PR TITLE
ci: Add copywrite workflow and makefile for easier local dev.

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,6 @@
+schema_version = 1
+
+project {
+  license        = "MPL-2.0"
+  copyright_year = 2014
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,17 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels: ["dependencies"]
+    groups:
+      go:
+        patterns:
+          - "*"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     labels:
       - dependencies
     groups:

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,0 +1,24 @@
+name: Check Copywrite Headers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        name: Setup Copywrite
+        with:
+          version: v0.25.3
+          archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
+      - name: Check Header Compliance
+        run: make copywriteheaders
+permissions:
+  contents: read

--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Run go tests
         run: |
           PACKAGE_NAMES=$(go list ./...)
-          gotestsum --format=short-verbose --junitfile $TEST_RESULTS/gotestsum-report.xml -- -p 2 -cover -coverprofile=coverage.out $PACKAGE_NAMES
+          gotestsum --format=short-verbose --junitfile $TEST_RESULTS/gotestsum-report.xml -- -race -p 2 -cover -coverprofile=coverage.out $PACKAGE_NAMES
       
       # Save coverage report parts
       - name: Upload and save artifacts

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+default: copywriteheaders lint test
+
+.PHONY: copywriteheaders
+copywriteheaders:
+	@echo "==> Running copywrite headers plan..."
+	@copywrite headers --plan
+	@echo "==> Done"
+
+.PHONY: deps
+deps:
+	@go install github.com/hashicorp/copywrite@b3e6599f43beff698f471c6f46888045453fa030 # v0.25.3
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@c0d3ddc9cf3faa61a4e378e879ece580256d76e5 # v2.12.2
+
+.PHONY: lint
+lint:
+	@echo "==> Running linters..."
+	@golangci-lint run
+	@echo "==> Done"
+
+.PHONY: test
+test:
+	@echo "==> Running tests..."
+	@go test -v -race -timeout=60s ./...
+	@echo "==> Done"


### PR DESCRIPTION
This change adds a new copywrite workflow to check for license compliance on PRs and merges.

The dependabot config has been slightly modified to group Go PR's and run all checks on a weekly schedule which matches other libraries.

The tests are also run with the race flag.

Jira: https://hashicorp.atlassian.net/browse/NMD-1555
