### PR TITLE
fix: empty Version.String() prints 0.0.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -439,7 +439,13 @@ func (v *Version) String() string {
 
 func (v *Version) bytes() []byte {
 	var buf []byte
-	for i, s := range v.segments {
+	// A zero value Version has no segments but compares equal to 0.0.0.
+	// Print the same canonical form so String matches Equal.
+	segments := v.segments
+	if len(segments) == 0 {
+		segments = []int64{0, 0, 0}
+	}
+	for i, s := range segments {
 		if i > 0 {
 			buf = append(buf, '.')
 		}

--- a/version_test.go
+++ b/version_test.go
@@ -673,6 +673,25 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func TestEmptyVersionStringMatchesZero(t *testing.T) {
+	// Zero-value Version compares equal to 0.0.0 but used to print "".
+	empty := &Version{}
+	zero, err := NewSemver("0.0.0")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !empty.Equal(zero) {
+		t.Fatalf("expected empty Version to Equal 0.0.0")
+	}
+	if got := empty.String(); got != "0.0.0" {
+		t.Fatalf("expected empty Version.String() = 0.0.0, got %q", got)
+	}
+	if got := zero.String(); got != "0.0.0" {
+		t.Fatalf("expected 0.0.0 String() = 0.0.0, got %q", got)
+	}
+}
+
 func TestGreaterThan(t *testing.T) {
 	cases := []struct {
 		v1       string


### PR DESCRIPTION
## Description

A zero-value `Version{}` compares equal to `0.0.0` (empty segment slices are treated as all zeros in `Compare`), but `String()` rebuilt from `segments` and printed `""`.

```go
v := &version.Version{}
vv, _ := version.NewSemver("0.0.0")
v.Equal(vv) // true
v.String()  // was "" — now "0.0.0"
```

## Fix

In `bytes()`, when `segments` is empty, use `{0, 0, 0}` so the printed form matches the equality semantics.

## Tests

```bash
go test ./... -count=1
```

Added `TestEmptyVersionStringMatchesZero`.

## Linked Issue

Closes #170
