### PR TITLE
fix: trim surrounding space in version and constraint parse

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -56,10 +56,10 @@ type constraintOperation struct {
 // constraint string. The string must be a comma-separated list of
 // constraints.
 func NewConstraint(v string) (Constraints, error) {
-	vs := strings.Split(v, ",")
+	vs := strings.Split(strings.TrimSpace(v), ",")
 	result := make([]*Constraint, len(vs))
 	for i, single := range vs {
-		c, err := parseSingle(single)
+		c, err := parseSingle(strings.TrimSpace(single))
 		if err != nil {
 			return nil, err
 		}

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -256,3 +256,17 @@ func TestConstraintsString(t *testing.T) {
 		}
 	}
 }
+
+func TestNewConstraintTrimSpace(t *testing.T) {
+	c, err := NewConstraint(" >= 1.0.0 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, err := NewVersion("1.2.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.Check(v) {
+		t.Fatal("expected match")
+	}
+}

--- a/version.go
+++ b/version.go
@@ -88,6 +88,7 @@ func NewVersion(v string, opts ...Option) (*Version, error) {
 		}
 	}
 
+	v = strings.TrimSpace(v)
 	vToParse := v
 	if options.prefix != "" {
 		if !strings.HasPrefix(v, options.prefix) {
@@ -109,7 +110,7 @@ func NewVersion(v string, opts ...Option) (*Version, error) {
 // Version that adheres strictly to SemVer specs
 // https://semver.org/
 func NewSemver(v string) (*Version, error) {
-	return newVersion(v, getSemverRegexp())
+	return newVersion(strings.TrimSpace(v), getSemverRegexp())
 }
 
 func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {

--- a/version_test.go
+++ b/version_test.go
@@ -911,3 +911,20 @@ func BenchmarkVersionCompareV2(b *testing.B) {
 		v.Compare(o)
 	}
 }
+
+func TestNewVersionTrimSpace(t *testing.T) {
+	v, err := NewVersion(" 1.2.3 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.String() != "1.2.3" {
+		t.Fatalf("got %s", v)
+	}
+	v, err = NewSemver(" 2.0.0 ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.String() != "2.0.0" {
+		t.Fatalf("semver got %s", v)
+	}
+}


### PR DESCRIPTION
## What

`NewVersion`, `NewSemver`, and `NewConstraint` trim leading/trailing whitespace before parsing.

## Why

Config files and CLI flags often leave padded values (`" 1.2.3 "`, `" >= 1.0.0 "`). Those failed parse even when the non-space content was valid.

## Test

- `TestNewVersionTrimSpace`
- `TestNewConstraintTrimSpace`