### PR TITLE
Rank a shorter prerelease lower, fixing non-transitive Compare

### DIFF
--- a/version.go
+++ b/version.go
@@ -277,19 +277,18 @@ func comparePart(preSelf string, preOther string) int {
 		otherNumeric = false
 	}
 
-	// if a part is empty, we use the other to decide
+	// A shorter prerelease (one that has run out of fields) has lower
+	// precedence than a longer one with the same leading identifiers, whatever
+	// the present field's type (SemVer 2.0.0 §11.4.4). Deciding by the other
+	// field's type made Compare non-transitive: with alpha < alpha.1 <
+	// alpha.beta, alpha was reported greater than alpha.beta, which also
+	// corrupts sort.Sort of a Collection.
 	if preSelf == "" {
-		if otherNumeric {
-			return -1
-		}
-		return 1
+		return -1
 	}
 
 	if preOther == "" {
-		if selfNumeric {
-			return 1
-		}
-		return -1
+		return 1
 	}
 
 	if selfNumeric && !otherNumeric {

--- a/version_test.go
+++ b/version_test.go
@@ -385,7 +385,9 @@ func TestComparePreReleases(t *testing.T) {
 		{"3.0-alpha.3", "3.0-rc.1", -1},
 		{"3.0-alpha3", "3.0-rc1", -1},
 		{"3.0-alpha.1", "3.0-alpha.beta", -1},
-		{"5.4-alpha", "5.4-alpha.beta", 1},
+		// A shorter prerelease is lower (SemVer 2.0.0 §11.4.4); this used to
+		// assert 1, which made Compare non-transitive against the line above.
+		{"5.4-alpha", "5.4-alpha.beta", -1},
 		{"v1.2-beta.2", "v1.2-beta.2", 0},
 		{"v1.2-beta.1", "v1.2-beta.2", -1},
 		{"v3.2-alpha.1", "v3.2-alpha", 1},
@@ -909,5 +911,24 @@ func BenchmarkVersionCompareV2(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		v.Compare(o)
+	}
+}
+
+func TestPrereleaseCompareIsTransitive(t *testing.T) {
+	// alpha < alpha.1 < alpha.beta, so alpha must be < alpha.beta. Deciding an
+	// empty prerelease field by the other field's type used to report alpha as
+	// greater than alpha.beta -- a non-transitive result that also corrupts
+	// sort.Sort of a Collection.
+	a := Must(NewSemver("1.0.0-alpha"))
+	b := Must(NewSemver("1.0.0-alpha.1"))
+	c := Must(NewSemver("1.0.0-alpha.beta"))
+	if a.Compare(b) >= 0 || b.Compare(c) >= 0 {
+		t.Fatalf("setup: want alpha < alpha.1 < alpha.beta")
+	}
+	if a.Compare(c) >= 0 {
+		t.Errorf("alpha should be < alpha.beta, got Compare = %d", a.Compare(c))
+	}
+	if c.Compare(a) <= 0 {
+		t.Errorf("alpha.beta should be > alpha, got Compare = %d", c.Compare(a))
 	}
 }


### PR DESCRIPTION
`comparePart` decides an empty (missing) prerelease field by whether the *other* field is numeric. With `1.0.0-alpha` < `1.0.0-alpha.1` < `1.0.0-alpha.beta`, that makes `alpha` compare **greater** than `alpha.beta`:

```
alpha    vs alpha.1     -> -1
alpha.1  vs alpha.beta  -> -1
alpha    vs alpha.beta  -> +1   (not transitive)
```

So `Compare` is not a total order, and `sort.Sort(Collection)` returns different results depending on input order. Per SemVer 2.0.0 §11.4.4 a smaller set of prerelease fields has lower precedence — a missing field ranks lower regardless of the other field's type.

One existing test asserted `5.4-alpha > 5.4-alpha.beta` (the transitively-inconsistent result); it is updated to match §11.4.4, plus a new transitivity check. `NewSemver` is documented as strictly following semver.org.
