### PR TITLE
fix: compare oversized numeric prerelease IDs with big.Int

### DIFF
--- a/version.go
+++ b/version.go
@@ -6,6 +6,7 @@ package version
 import (
 	"database/sql/driver"
 	"fmt"
+	"math/big"
 	"regexp"
 	"strconv"
 	"strings"
@@ -263,19 +264,8 @@ func comparePart(preSelf string, preOther string) int {
 		return 0
 	}
 
-	var selfInt int64
-	selfNumeric := true
-	selfInt, err := strconv.ParseInt(preSelf, 10, 64)
-	if err != nil {
-		selfNumeric = false
-	}
-
-	var otherInt int64
-	otherNumeric := true
-	otherInt, err = strconv.ParseInt(preOther, 10, 64)
-	if err != nil {
-		otherNumeric = false
-	}
+	selfInt, selfNumeric := new(big.Int).SetString(preSelf, 10)
+	otherInt, otherNumeric := new(big.Int).SetString(preOther, 10)
 
 	// if a part is empty, we use the other to decide
 	if preSelf == "" {
@@ -298,8 +288,8 @@ func comparePart(preSelf string, preOther string) int {
 		return 1
 	} else if !selfNumeric && !otherNumeric && preSelf > preOther {
 		return 1
-	} else if selfInt > otherInt {
-		return 1
+	} else if selfNumeric && otherNumeric {
+		return selfInt.Cmp(otherInt)
 	}
 
 	return -1

--- a/version_test.go
+++ b/version_test.go
@@ -390,6 +390,11 @@ func TestComparePreReleases(t *testing.T) {
 		{"v1.2-beta.1", "v1.2-beta.2", -1},
 		{"v3.2-alpha.1", "v3.2-alpha", 1},
 		{"v3.2-rc.1-1-g123", "v3.2-rc.2", 1},
+		// Numeric identifiers larger than int64 must still compare numerically.
+		{"1.2-99999999999999999999", "1.2-100000000000000000000", -1},
+		{"1.2-100000000000000000000", "1.2-99999999999999999999", 1},
+		{"1.2-9223372036854775807", "1.2-9223372036854775808", -1},
+		{"1.2-100000000000000000000", "1.2-alpha", -1},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
`comparePart` used `strconv.ParseInt`, so digit-only prerelease identifiers larger than int64 fell back to string comparison. That made `1.2-99999999999999999999` sort *after* `1.2-100000000000000000000`.

Parse both sides with `math/big` and use `Cmp` so SemVer numeric ordering still holds past int64.

Fixes #204

## Test plan
- [x] `go test -count=1 -run '^TestComparePreReleases$' .`
- [x] `go test -race -count=1 ./...`
- [x] New cases cover the issue repro, int64 boundary, and numeric vs alphanumeric